### PR TITLE
fix hash randomization bug with Perl 5.18 and above

### DIFF
--- a/lib/Geo/Address/Formatter.pm
+++ b/lib/Geo/Address/Formatter.pm
@@ -162,7 +162,7 @@ sub format_address {
     #warn Dumper $rh_components;
 
     # set the aliases, unless this would overwrite something
-    foreach my $alias (keys %{$self->{component_aliases}}){
+    foreach my $alias (sort keys %{$self->{component_aliases}}){
 
         if (defined($rh_components->{$alias})
             && !defined($rh_components->{$self->{component_aliases}->{$alias}})
@@ -341,7 +341,7 @@ sub _apply_replacements {
     my $raa_rules     = shift;
 
     #warn Dumper $raa_rules;
-    foreach my $key ( keys %$rh_components ){
+    foreach my $key ( sort keys %$rh_components ){
         foreach my $ra_fromto ( @$raa_rules ){
 
             try {
@@ -393,7 +393,7 @@ sub _render_template {
 
     # is it empty?
     if ($output !~ m/\w/){
-        my @comps = keys %$components;
+        my @comps = sort keys %$components;
         if (scalar(@comps) == 1){  
             foreach my $k (@comps){
                 $output = $components->{$k};
@@ -410,7 +410,7 @@ sub _find_unknown_components {
     my $components = shift;
 
     my %h_known = map { $_ => 1 } @{ $self->{ordered_components} };
-    my @a_unknown = grep { !exists($h_known{$_}) } keys %$components;
+    my @a_unknown = grep { !exists($h_known{$_}) } sort keys %$components;
 
     #warn Dumper \@a_unknown;
     return \@a_unknown;


### PR DESCRIPTION
Changed 'keys' to 'sort keys' where it matters.

---

This Pull Request "fixes the problem", by which I mean that it makes it so that the test _always_ fails :-P To make it so it always passes requires a change in the address-formatting submodule which I wasn't sure how to fix.
