### PR TITLE
replace template lambda subroutines with simpler regular expressions

### DIFF
--- a/t/unit/formatter.t
+++ b/t/unit/formatter.t
@@ -112,7 +112,8 @@ my $GAF  = $CLASS->new(conf_path => $path);
 
 
 {
-    my $THT = Text::Hogan::Compiler->new->compile('abc {{#first}} {{one}} || {{two}} {{/first}} def');
+    my $template_text = $GAF->_replace_template_lambdas('abc {{#first}} {{one}} || {{two}} {{/first}} def');
+    my $THT = Text::Hogan::Compiler->new->compile($template_text);
     is($GAF->_render_template($THT, {two => 2}), "abc 2 def\n", '_render_template - first');
 }
 

--- a/t/unit/memory_use.t
+++ b/t/unit/memory_use.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use feature qw(say);
+use File::Basename qw(dirname);
+use Test::More;
+
+## We used to have memory leak, 100.000 random could consume 300MB RAM
+## due to Text::Hogan caching subroutines in template $context.
+plan(skip_all => 'Skip long-running memory usage tests');
+
+
+use lib 'lib';
+
+my $af_path = dirname(__FILE__) . '/../../address-formatting';
+my $conf_path = $af_path . '/conf/';
+
+my $CLASS = 'Geo::Address::Formatter';
+use_ok($CLASS);
+
+my $GAF = $CLASS->new(conf_path => $conf_path);
+
+my @a_components = qw(
+    house_number
+    road
+    hamlet
+    village
+    neighbourhood
+    postal_city    
+    city
+    municipality
+    county
+    postcode
+    state
+    region
+);
+
+foreach my $i (0..100_000) {
+    note $i if (++$i % 5_000 == 0);
+
+    my %h_address = ( country_code => 'de' );
+    foreach my $k (@a_components) {
+        $h_address{$k} = "$k-$i";
+    }
+
+    say $GAF->format_address(\%h_address);
+}
+
+done_testing();
+
+1;


### PR DESCRIPTION
The templates we use contains blocks like `{{#first}} {{{city}}} || {{{town}}} {{/first}}`. In Mustache template systems one can supply custom lambdas (code/subroutine) which will evaluate those blocks. We used to set a lambda called `first` in `_render_template()`. The lambda required access to the `%components` hash to evaluate the remaining template variables.

Turns out the `Text::Hogan` template engine does some caching of lambdas (irregardless if the compiled template was already cached). Calling `template->render` with lambdas that accessed address data consumed memory for each call. There's no option in `Text::Hogan` to control the behaviour.

I added a `t/unit/memory_use.t` test file. It's switched off by default. Before this PR the tests would consume 300 megabyte extra RAM.

This PR changes the logic: In the template we replace `FIRSTSTART_9349813734 {{{city}}} || {{{town}}} FIRSTEND_9349813734`. After the rendering we inspect, e.g. `FIRSTSTART_9349813734  || Berlin FIRSTEND_9349813734` and return the first value `Berlin`.

I hope the start and end identifiers are unique enough. It's possible to come up with a different syntax later. There were no changes needed to the address-formatting templates we already use. Unclear if address formatters in other programming languages are effected similarly, I suspect it's Perl specific.