### PR TITLE
no random ids in _replace_template_lambdas

### DIFF
--- a/lib/Geo/Address/Formatter.pm
+++ b/lib/Geo/Address/Formatter.pm
@@ -783,8 +783,7 @@ sub _render_template {
 sub _replace_template_lambdas {
     my $self          = shift;
     my $template_text = shift;
-    my $rand_id = sprintf('%010d', rand()* 10_000_000);
-    $template_text =~ s!\Q{{#first}}\E(.+?)\Q{{/first}}\E!FIRSTSTART_${rand_id}${1}FIRSTEND_${rand_id}!g;
+    $template_text =~ s!\Q{{#first}}\E(.+?)\Q{{/first}}\E!FIRSTSTART${1}FIRSTEND!g;
     return $template_text;
 }
 
@@ -792,7 +791,7 @@ sub _replace_template_lambdas {
 sub _evaluate_template_lamdas {
     my $self = shift;
     my $text = shift;
-    $text =~ s!FIRSTSTART_\d+\s*(.+?)\s*FIRSTEND_\d+!_select_first($1)!segx;
+    $text =~ s!FIRSTSTART\s*(.+?)\s*FIRSTEND!_select_first($1)!seg;
     return $text;
 }
 

--- a/t/unit/memory_use.t
+++ b/t/unit/memory_use.t
@@ -42,7 +42,7 @@ foreach my $i (0..100_000) {
         $h_address{$k} = "$k-$i";
     }
 
-    say $GAF->format_address(\%h_address);
+    $GAF->format_address(\%h_address);
 }
 
 done_testing();


### PR DESCRIPTION
https://github.com/OpenCageData/perl-Geo-Address-Formatter/pull/8 added a regression. While executing 100.000 'format_address' took 2m58s in version 1.89, it took 4m9s in version 1.91. With this PR it's down to 2m53s again.