### PR TITLE
Skip invalid component names

### DIFF
--- a/lib/Geo/Address/Formatter.pm
+++ b/lib/Geo/Address/Formatter.pm
@@ -287,6 +287,13 @@ sub format_address {
 
     # 2. deal with the options
 
+    foreach (grep { ! /^[a-z0-9_]+$/ } keys %$rh_components) {
+        if ($debug){
+            say STDERR "Skipping compontent $_";
+        }
+        delete $rh_components->{$_};
+    }
+
     # 2a. which country format will we use?
     #     might have been specified in options
     #     otherwise look at components

--- a/t/unit/formatter.t
+++ b/t/unit/formatter.t
@@ -46,6 +46,32 @@ my $GAF  = $CLASS->new(conf_path => $path);
     }
 }
 
+# Make sure invalid component names are skipped
+{
+    my $af_path   = dirname(__FILE__) . '/../../address-formatting';
+    my $conf_path = $af_path . '/conf/';
+    my $GAF       = $CLASS->new(conf_path => $conf_path);
+
+    my $rh_components = {
+          '' => 'empty',
+          '*' => 'star',
+          '+' => 'plus',
+          '\\' => 'escape',
+          '$' => 'dollar',
+          '(' => 'bracket',
+          '\(' => 'quoted bracket',
+          'country' => 'United Kingdom',
+          'country_code' => 'gb',
+    };
+
+    my $formatted = $GAF->format_address($rh_components, {});
+    chomp $formatted;
+
+    is($formatted, 'United Kingdom');
+}
+
+
+
 {
     # keep in mind this is using the test conf, not the real address-formatting conf
     is($GAF->_add_state_code({}), undef);


### PR DESCRIPTION
We loop through component names and use regular expression for applying replacements. Instead of quoting the regular expressions everywhere it's easier to make sure the component names never contain special characters (or be empty).